### PR TITLE
refactor: cleanup env names after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ An error will be thrown if the path to the binary cannot be resolved.
 
 ### Caching
 
-Downloaded archives are placed in OS-specific cache directory which can be customized by setting `NPM_GO_IPFS_CACHE` in env.
+Downloaded archives are placed in OS-specific cache directory which can be customized by setting `NPM_KUBO_CACHE` in env.
 
 ### Overriding with `KUBO_BINARY` env
 

--- a/src/download.js
+++ b/src/download.js
@@ -33,7 +33,7 @@ const isWin = process.platform === 'win32'
  * @param {string} url
  */
 async function cachingFetchAndVerify (url) {
-  const cacheDir = process.env.NPM_GO_IPFS_CACHE || cachedir('npm-kubo')
+  const cacheDir = process.env.NPM_KUBO_CACHE || process.env.NPM_GO_IPFS_CACHE || cachedir('npm-kubo')
   const filename = url.split('/').pop()
 
   if (!filename) {
@@ -124,7 +124,7 @@ function cleanArguments (version, platform, arch, installPath) {
     version: process.env.TARGET_VERSION || version || conf.version,
     platform: process.env.TARGET_OS || platform || goenv.GOOS,
     arch: process.env.TARGET_ARCH || arch || goenv.GOARCH,
-    distUrl: process.env.GO_IPFS_DIST_URL || conf.distUrl,
+    distUrl: process.env.KUBO_DIST_URL || process.env.GO_IPFS_DIST_URL || conf.distUrl,
     installPath: installPath ? path.resolve(installPath) : process.cwd()
   }
 }

--- a/test/download.js
+++ b/test/download.js
@@ -26,7 +26,19 @@ test('Returns an error when version unsupported', async (t) => {
   t.end()
 })
 
-test('Returns an error when dist url is 404', async (t) => {
+test('Returns an error when KUBO_DIST_URL is 404', async (t) => {
+  await clean()
+
+  process.env.KUBO_DIST_URL = 'https://dist.ipfs.tech/notfound'
+
+  await t.rejects(download(), /404/)
+
+  delete process.env.KUBO_DIST_URL
+
+  t.end()
+})
+
+test('Returns an error when legacy GO_IPFS_DIST_URL is 404', async (t) => {
   await clean()
 
   process.env.GO_IPFS_DIST_URL = 'https://dist.ipfs.tech/notfound'
@@ -37,6 +49,7 @@ test('Returns an error when dist url is 404', async (t) => {
 
   t.end()
 })
+
 
 test('Path returns undefined when no binary has been downloaded', async (t) => {
   await clean()


### PR DESCRIPTION
This PR finishes rename from  https://github.com/ipfs/npm-go-ipfs/issues/51  by switching remaining env variables to "Kubo".
Old ones still work, if someone has them set, so this is not a breaking change.