### PR TITLE
fix: windows uses hard links

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -204,7 +204,11 @@ async function link ({ depBin, version }) {
   }
 
   console.info('Linking', depBin, 'to', localBin)
-  fs.symlinkSync(depBin, localBin)
+  if (isWin) {
+    fs.linkSync(depBin, localBin)
+  } else {
+    fs.symlinkSync(depBin, localBin)
+  }
 
   if (isWin) {
     // On Windows, update the shortcut file to use the .exe


### PR DESCRIPTION
there are other ways to solve this (copy, move, etc) 
or using packages like `lnk` but I wanted to fix without 
additional dependencies or change in functionality

fixes #68
