### PR TITLE
feat: expose standalone download function

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -237,12 +237,22 @@ async function link ({ depBin, version }) {
 }
 
 /**
+* @param {object} options
+* @param {string} options.version
+* @param {string} options.platform
+* @param {string} options.arch
+* @param {string} options.installPath
+* @param {string} options.distUrl
+*/
+module.exports.download = download
+
+/**
  * @param {string} [version]
  * @param {string} [platform]
  * @param {string} [arch]
  * @param {string} [installPath]
  */
-module.exports = async (version, platform, arch, installPath) => {
+module.exports.downloadAndUpdateBin = async (version, platform, arch, installPath) => {
   const args = cleanArguments(version, platform, arch, installPath)
 
   return link({

--- a/src/go-platform.js
+++ b/src/go-platform.js
@@ -2,10 +2,10 @@
 
 function getGoOs () {
   switch (process.platform) {
-    case "sunos":
-      return "solaris"
-    case "win32":
-      return "windows"
+    case 'sunos':
+      return 'solaris'
+    case 'win32':
+      return 'windows'
   }
 
   return process.platform
@@ -13,19 +13,18 @@ function getGoOs () {
 
 function getGoArch () {
   switch (process.arch) {
-    case "ia32":
-      return "386"
-    case "x64":
-      return "amd64"
-    case "arm":
-      return "arm"
-    case "arm64":
-      return "arm64"
+    case 'ia32':
+      return '386'
+    case 'x64':
+      return 'amd64'
+    case 'arm':
+      return 'arm'
+    case 'arm64':
+      return 'arm64'
   }
 
   return process.arch
 }
-
 
 module.exports = {
   GOOS: getGoOs(),

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@
 
 const fs = require('fs')
 const path = require('path')
+const { download } = require('./download')
+
+module.exports.download = download
 
 module.exports.path = function () {
   if (process.env.KUBO_BINARY) {

--- a/src/post-install.js
+++ b/src/post-install.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const download = require('./download')
+const { downloadAndUpdateBin } = require('./download')
 
-download()
+downloadAndUpdateBin()
   .catch(err => {
     console.error(err)
     process.exit(1)


### PR DESCRIPTION
This PR exposes manual `download` function that allows downloading binaries for more than one platform in programmatic fashion.

Use case: we want to use this in ipfs-desktop, to download both amd64 and arm64 binaries required for building universal DMGs (https://github.com/ipfs/ipfs-desktop/pull/1856).

Exposing `download` function here allows us to:
1. leverage cached downloads, avoiding fetching same base arch artifact twice
2. confirm download was successful by checking sha512