### PR TITLE
fix(windows): remove the need for admin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check for new kubo version
         id: check
         uses: ./.github/actions/check-for-kubo-release
       - name: Set up node
         if: steps.check.outputs.publish == 'true'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Install
         if: steps.check.outputs.publish == 'true'
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, linux-latest]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 14.x
+        node-version: ${{ matrix.node-version }}
     - run: npm install
     - uses: gozala/typescript-error-reporter-action@v1.0.9
     - run: npm run build --if-present

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, linux-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         node-version: [20.x]
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This module downloads Kubo (go-ipfs) binaries from https://dist.ipfs.tech into y
 
 It will download the kubo version that matches the npm version of this module. So depending on `kubo@0.23.0` will install `kubo v0.23.0` for your current system architecture, in to your project at `node_modules/kubo/kubo/ipfs` and additional symlink to it at `node_modules/kubo/bin/ipfs`.
 
+On Windows, `ipfs.exe` file is used, and if the symlink can't be created under a regular user, a copy of `ipfs.exe` is created instead.
+
 After downloading you can find out the path of the installed binary by calling the `path` function exported by this module:
 
 ```javascript

--- a/src/download.js
+++ b/src/download.js
@@ -192,6 +192,9 @@ async function link ({ depBin, version }) {
   let localBin = path.resolve(path.join(__dirname, '..', 'bin', 'ipfs'))
 
   if (isWin) {
+    if (fs.existsSync(localBin)) {
+      fs.unlinkSync(localBin)
+    }
     localBin += '.exe'
   }
 

--- a/src/download.js
+++ b/src/download.js
@@ -204,7 +204,23 @@ async function link ({ depBin, version }) {
   }
 
   console.info('Linking', depBin, 'to', localBin)
-  fs.symlinkSync(depBin, localBin)
+  try {
+    fs.symlinkSync(depBin, localBin)
+  } catch (err) {
+    // Try to recover when creating symlink on modern Windows fails (https://github.com/ipfs/npm-kubo/issues/68)
+    if (isWin && typeof err === 'object' && err !== null && 'code' in err && err.code === 'EPERM') {
+      console.info('Symlink creation failed due to insufficient privileges. Attempting to copy file instead...')
+      try {
+        fs.copyFileSync(depBin, localBin)
+        console.info('Copying', depBin, 'to', localBin)
+      } catch (copyErr) {
+        console.error('File copy also failed:', copyErr)
+        throw copyErr
+      }
+    } else {
+      throw err
+    }
+  }
 
   if (isWin) {
     // On Windows, update the shortcut file to use the .exe

--- a/test/download.js
+++ b/test/download.js
@@ -3,7 +3,7 @@
 const test = require('tape-promise').default(require('tape'))
 const fs = require('fs-extra')
 const os = require('os')
-const path= require('path')
+const path = require('path')
 const { download, downloadAndUpdateBin } = require('../src/download')
 const { path: detectLocation } = require('../')
 const clean = require('./fixtures/clean')
@@ -72,7 +72,7 @@ test('Ensure calling download function manually with static values works', async
     platform: 'darwin',
     arch: 'arm64',
     distUrl: 'https://dist.ipfs.tech',
-    installPath: tempDir,
+    installPath: tempDir
   })
   console.log(kuboPath)
   const stats = await fs.stat(kuboPath)

--- a/test/path.js
+++ b/test/path.js
@@ -4,6 +4,10 @@ var path = require('path')
 var cp = require('child_process')
 var ipfs = path.join(__dirname, '..', 'bin', 'ipfs')
 
+if (process.platform === 'win32') {
+  ipfs += '.exe'
+}
+
 test('ensure ipfs bin path exists', function (t) {
   t.plan(4)
   fs.stat(ipfs, function (err, stats) {


### PR DESCRIPTION
Seems symllink now triggers admin prompt.

Running NPM with admin is not wise, instead we fallback to copying when on Windows.

- [x] fix #68 
  - confirmed this works on borrowed Windows 10 laptop:
    - [x] `npm i --save kubo@0.29.0-rc2` produced `EPERM` error
    - [x] `npm i --save ipfs/npm-kubo#pull/74/head`  installed just fine, and without prompting for Admin
- [x] update CI in this repo to run tests on macos and windows
- [x] test in https://github.com/ipfs/ipfs-desktop/pull/1856 with latest LTS

Closes #68