### PR TITLE
ci: migrate to npm trusted publishing

### DIFF
--- a/.github/actions/check-for-kubo-release/entrypoint.sh
+++ b/.github/actions/check-for-kubo-release/entrypoint.sh
@@ -3,13 +3,13 @@ set -eu
 
 echo '💫 Checking https://dist.ipfs.tech/kubo/versions for new releases...'
 
-# The version in packge.json e.g. "0.4.20"
-CURRENT=`node -e 'console.log(require("./package.json").version)'`
+# The version in package.json e.g. "0.4.20"
+CURRENT=$(node -e 'console.log(require("./package.json").version)')
 # The latest version on dist.ipfs.tech e.g. "0.4.21"
-LATEST=`curl --silent https://dist.ipfs.tech/kubo/versions | tail -n 1 | cut -c 2-`
+LATEST=$(curl --silent --show-error --fail https://dist.ipfs.tech/kubo/versions | tail -n 1 | cut -c 2-)
 
 # Verify $LATEST is valid semver!
-if ! npx semver $LATEST; then
+if ! npx semver "$LATEST"; then
   echo "⚠️  Ignoring version $LATEST - Invalid SemVer string"
   exit 1
 fi
@@ -17,9 +17,9 @@ fi
 if [[ "$CURRENT" != "$LATEST" ]]; then
   echo "🎉 New release exists $LATEST"
 
-  echo "publish=true" >> $GITHUB_OUTPUT
+  echo "publish=true" >> "$GITHUB_OUTPUT"
 else
   echo "💤 $CURRENT is the latest release. Going back to sleep"
 
-  echo "publish=false" >> $GITHUB_OUTPUT
+  echo "publish=false" >> "$GITHUB_OUTPUT"
 fi

--- a/.github/actions/publish/Dockerfile
+++ b/.github/actions/publish/Dockerfile
@@ -1,9 +1,0 @@
-FROM node:14
-
-LABEL "com.github.actions.name"="Version and publish"
-LABEL "com.github.actions.description"="npm version and publish with new kubo version"
-LABEL "com.github.actions.icon"="box"
-LABEL "com.github.actions.color"="green"
-
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -1,4 +1,7 @@
 name: 'Publish release'
+description: 'Bump version, publish to npm with provenance via Trusted Publishing, and push changes back to origin'
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: ${{ github.action_path }}/entrypoint.sh

--- a/.github/actions/publish/entrypoint.sh
+++ b/.github/actions/publish/entrypoint.sh
@@ -1,74 +1,50 @@
 #!/usr/bin/env bash
 set -eu
 
-# Set up npm home, so `npm publish` works.
-# https://github.com/actions/npm/blob/59b64a598378f31e49cb76f27d6f3312b582f680/entrypoint.sh
-if [ -n "$NPM_AUTH_TOKEN" ]; then
-  # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
-  NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
-  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
-  NPM_STRICT_SSL="${NPM_STRICT_SSL-true}"
-  NPM_REGISTRY_SCHEME="https"
-  if ! $NPM_STRICT_SSL
-  then
-    NPM_REGISTRY_SCHEME="http"
-  fi
+# Current version in package.json (e.g. "0.4.20")
+CURRENT=$(node -e 'console.log(require("./package.json").version)')
+# Latest version on dist.ipfs.tech (e.g. "0.4.21")
+LATEST=$(curl --silent --show-error --fail https://dist.ipfs.tech/kubo/versions | tail -n 1 | cut -c 2-)
 
-  # Allow registry.npmjs.org to be overridden with an environment variable
-  printf "//%s/:_authToken=%s\\nregistry=%s\\nstrict-ssl=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "${NPM_REGISTRY_SCHEME}://$NPM_REGISTRY_URL" "${NPM_STRICT_SSL}" > "$NPM_CONFIG_USERCONFIG"
-
-  chmod 0600 "$NPM_CONFIG_USERCONFIG"
-fi
-
-# The version in packge.json e.g. "0.4.20"
-CURRENT=`node -e 'console.log(require("./package.json").version)'`
-# The latest version on dist.ipfs.tech e.g. "0.4.21"
-LATEST=`curl --silent https://dist.ipfs.tech/kubo/versions | tail -n 1 | cut -c 2-`
-
-# Verify $LATEST is valid semver!
-if ! npx semver $LATEST; then
+# Verify $LATEST is valid semver
+if ! npx semver "$LATEST"; then
   echo "⚠️  Ignoring version $LATEST - Invalid SemVer string"
   exit 1
 fi
 
-if [[ "$CURRENT" != "$LATEST" ]]; then
-
-  # If the version contains a dash it's a pre-release, e.g "0.4.21-rc3"
-  # Publish pre-releases under the @next tag and releases @latest tag.
-  if [[ $LATEST =~ "-" ]]; then
-    NPM_DIST_TAG='next'
-    echo "🧪 Found new kubo pre-release $LATEST@$NPM_DIST_TAG"
-  else
-    NPM_DIST_TAG='latest'
-    echo "🎉 Found new kubo release $LATEST@$NPM_DIST_TAG"
-  fi
-
-  git config --global --add safe.directory /github/workspace
-  
-  # The workspace starts as a detached commit for scheduled builds...
-  git rev-parse --abbrev-ref HEAD
-  git checkout master
-
-  # post-install rewrites bin/ipfs so undo that change
-  git checkout -- bin/ipfs
-
-  # Set sensible commit info
-  git config --global user.name "${GITHUB_ACTOR}"
-  git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-  
-  
-  npm install
-  npm version $LATEST
-  npm publish --access public --tag $NPM_DIST_TAG
-  echo "📦 Published $LATEST to npm as kubo@$NPM_DIST_TAG"
-
-  git push -u origin master
-  git push --tags
-  echo "👍 Pushed changes back to master"
-
-else
-  echo "💤 $CURRENT is the latest release. Going back to sleep"
-  # neutral github action exit... not good, not bad.
-  # https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses
-  exit 78
+if [[ "$CURRENT" == "$LATEST" ]]; then
+  echo "💤 $CURRENT is already the latest release. Nothing to do."
+  exit 0
 fi
+
+# If the version contains a dash it's a pre-release (e.g. "0.4.21-rc3").
+# Publish pre-releases under the @next tag and full releases under @latest.
+if [[ "$LATEST" =~ - ]]; then
+  NPM_DIST_TAG='next'
+  echo "🧪 Found new kubo pre-release $LATEST@$NPM_DIST_TAG"
+else
+  NPM_DIST_TAG='latest'
+  echo "🎉 Found new kubo release $LATEST@$NPM_DIST_TAG"
+fi
+
+# The workspace starts as a detached commit for scheduled builds.
+git checkout master
+
+# post-install rewrites bin/ipfs, so undo that change before committing.
+git checkout -- bin/ipfs
+
+# Set sensible commit info
+git config --global user.name  "${GITHUB_ACTOR}"
+git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+npm version "$LATEST"
+
+# --provenance emits a sigstore attestation alongside the tarball.
+# Authentication is handled by npm via OIDC (Trusted Publishing) using the
+# id-token permission granted to this job; no NPM_AUTH_TOKEN is needed.
+npm publish --provenance --access public --tag "$NPM_DIST_TAG"
+echo "📦 Published $LATEST to npm as kubo@$NPM_DIST_TAG"
+
+git push -u origin master
+git push --tags
+echo "👍 Pushed changes back to master"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to push the version bump commit and tag back to master.
+      contents: write
+      # Needed for npm Trusted Publishing (OIDC). Required by `npm publish`
+      # when the package is configured with a Trusted Publisher on npmjs.com.
+      # https://docs.npmjs.com/trusted-publishers
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -15,9 +22,11 @@ jobs:
         uses: ./.github/actions/check-for-kubo-release
       - name: Set up node
         if: steps.check.outputs.publish == 'true'
+        # Node 24 ships npm >= 11.5.1, which is required for OIDC Trusted Publishing.
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
       - name: Install
         if: steps.check.outputs.publish == 'true'
         run: npm install
@@ -27,5 +36,3 @@ jobs:
       - name: Publish
         if: steps.check.outputs.publish == 'true'
         uses: ./.github/actions/publish
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [Usage](#usage)
 - [Development](#development)
   - [Publish a new version](#publish-a-new-version)
+    - [Authentication (npm Trusted Publishing)](#authentication-npm-trusted-publishing)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -77,47 +78,22 @@ This must point to the file, not the directory containing the file.
 
 ### Publish a new version
 
-You should be able to just run `./publish.sh` for example:
+Publishing is automated. The [`Release to npm`](./.github/workflows/main.yml) workflow runs hourly, checks `https://dist.ipfs.tech/kubo/versions` for a new release, and if one is found:
 
-```sh
-> ./publish.sh
-usage ./publish.sh <version>
-publish a version of kubo to npm
+- bumps `version` in `package.json` via `npm version`
+- publishes to npm as `kubo@<version>` with a [sigstore provenance attestation](https://docs.npmjs.com/generating-provenance-statements)
+- pushes the version commit and tag back to `master`
 
-> ./publish.sh 0.3.11
-```
+The workflow tags full kubo releases as `latest` and pre-releases (any version containing `-`, e.g. `0.41.0-rc2`) as `next`.
 
-This will:
+Maintainers can also trigger a run manually from the [Actions tab](https://github.com/ipfs/npm-kubo/actions/workflows/main.yml) via `workflow_dispatch`.
 
-- check the version is indeed a tag in https://github.com/ipfs/kubo
-- check the size of `bin/ipfs` is right (must be the checked in file)
-- update the version numbers in `package.json` and `README.md`
-- `git commit` the changes
-- push to https://github.com/ipfs/npm-kubo
-- publish to `kubo@$version` to https://npmjs.com/package/kubo
+#### Authentication (npm Trusted Publishing)
 
-Open an issue in the repo if you run into trouble.
+The workflow authenticates to npm via [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) over GitHub OIDC, not a long-lived `NPM_AUTH_TOKEN`. To (re)configure trust on npmjs.com, a maintainer with publish rights should:
 
-### Publish a new version of this module with exact same kubo version
-
-If some problem happens, and you need to publish a new version of this module targetting _the same_ kubo version, then please follow this convention:
-
-1. **Clean up bad stuff:** unpublish all modules with this exact same `<kubo-version>`
-2. **Add a "hacky" version suffix:** use version: `<kubo-version>-hacky<num>`
-3. **Publish version:** publish the module. Since it's the only one with the kubo version, then it should be installed.
-
-> Why do this?
-
-Well, if you previously published npm module `kubo@0.4.0` and there was a problem, we now must publish a different version, but we want to keep the version number the same. so the strategy is to publish as `kubo@0.4.0-hacky1`, and unpublish `kubo@0.4.0`.
-
-> Why `-hacky<num>`?
-
-Because it is unlikely to be a legitimate kubo version, and we want to support kubo versions like `floodsub-1` etc.
-
-> Do i have to say `-hacky<num>` or can i just use `-<num>`?
-
-`-<num>` won't work, as [link-ipfs.js](./link-ipfs.js) expects `-hacky<num>`. If you want to
-change the convention, go for it, and update this readme accordingly.
+1. Go to the [`kubo` package settings on npmjs.com](https://www.npmjs.com/package/kubo/access) → **Trusted Publishers** → **Add trusted publisher** → **GitHub Actions**.
+2. Set organization `ipfs`, repository `npm-kubo`, workflow filename `main.yml`. Leave the environment field blank.
 
 ## Contribute
 


### PR DESCRIPTION
Unblocking 0.41.0 release

cc https://github.com/ipfs/kubo/issues/11082

Authenticate publishes via GitHub OIDC instead of a long-lived NPM_AUTH_TOKEN, and emit sigstore provenance on each tarball.

- main.yml: grant id-token and contents write perms, bump node to 24 (npm >= 11.5.1 for OIDC), drop NPM_AUTH_TOKEN wiring
- actions/publish: convert docker/node:14 to composite, drop .npmrc token plumbing, publish with --provenance
- entrypoint scripts: fail loud on curl errors, quote shellcheck-flagged expansions
- README: replace stale publish.sh instructions with the automated flow and npmjs.com trusted-publisher setup